### PR TITLE
Fixed an issue with the spawn position array index during player initialization in Bomberman sample.

### DIFF
--- a/Samples~/Bomberman/Scripts/BombermanEventsHandler.cs
+++ b/Samples~/Bomberman/Scripts/BombermanEventsHandler.cs
@@ -43,7 +43,7 @@ namespace Netick.Samples.Bomberman
     {
       if (IsClient)
         return;
-      var playerObj = sandbox.NetworkInstantiate(_playerPrefab, _spawnPositions[Sandbox.Players.Count], Quaternion.identity, player).GetComponent<BombermanController>();
+      var playerObj = sandbox.NetworkInstantiate(_playerPrefab, _freePositions.Dequeue(), Quaternion.identity, player).GetComponent<BombermanController>();
       sandbox.SetPlayerObject(player, playerObj.Object);
       AlivePlayers.Add(playerObj);
     }


### PR DESCRIPTION
- During player initialization, index 0 of the `_spawnPositions` array is not being used.
- If a player leaves and then rejoins, they may be assigned a spawn position that is already in use.
- It is believed that using the unused `_freePositions` is the intended behavior.